### PR TITLE
[Chore] GitHub Actions Cron Offset 적용

### DIFF
--- a/.github/workflows/schedule_academic_calendar.yml
+++ b/.github/workflows/schedule_academic_calendar.yml
@@ -2,7 +2,7 @@ name: Schedule Academic Calendar
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0-12 * * *"
+    - cron: "27 0-12 * * *"
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/schedule_cafeteria.yml
+++ b/.github/workflows/schedule_cafeteria.yml
@@ -2,7 +2,7 @@ name: Schedule Cafeteria
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0-12 * * *"
+    - cron: "17 0-12 * * *"
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/schedule_notice.yml
+++ b/.github/workflows/schedule_notice.yml
@@ -2,7 +2,7 @@ name: Schedule Notice
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0-12 * * *"
+    - cron: "7 0-12 * * *"
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/schedule_shuttle.yml
+++ b/.github/workflows/schedule_shuttle.yml
@@ -2,7 +2,7 @@ name: Schedule Shuttle
 on:
   workflow_dispatch:
   schedule:
-    - cron: "*/30 0-12 * * *"
+    - cron: "7,37 0-12 * * *"
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
- close #9

## 📝 기능 설명

GitHub Actions `schedule` 이벤트는 정확한 시간 실행을 보장하지 않으며, 매시 정각(`:00`)과 30분(`:30`)은 GitHub Actions 인프라 혼잡 시간대로 스케줄 지연 및 누락이 발생할 수 있습니다.

기존 cron 설정이 `:00`과 `:30`에 정확히 실행되도록 구성되어 있어, 실제 실행 간격이 200분 이상 벌어지는 문제가 확인되었습니다. 혼잡 시간대를 피하도록 cron minute offset을 적용합니다.

## 🛠 작업 사항

4개 워크플로 파일의 cron minute offset 적용

| 워크플로 | 변경 전 | 변경 후 |
|---------|--------|--------|
| `schedule_shuttle.yml` | `*/30 0-12 * * *` | `7,37 0-12 * * *` |
| `schedule_notice.yml` | `0 0-12 * * *` | `7 0-12 * * *` |
| `schedule_cafeteria.yml` | `0 0-12 * * *` | `17 0-12 * * *` |
| `schedule_academic_calendar.yml` | `0 0-12 * * *` | `27 0-12 * * *` |

변경 후 실행 시간:

```
shuttle:           00:07, 00:37, 01:07, 01:37 ... (KST 09:07, 09:37, 10:07 ...)
notice:            00:07, 01:07, 02:07 ...
cafeteria:         00:17, 01:17, 02:17 ...
academic_calendar: 00:27, 01:27, 02:27 ...
```

notice / cafeteria / academic_calendar에 각각 다른 분(7, 17, 27)을 사용해 워크플로 간 실행 시점도 분산시켰습니다.

## ✅ 작업 체크리스트

- [x] `schedule_shuttle.yml`: `*/30 0-12 * * *` → `7,37 0-12 * * *`
- [x] `schedule_notice.yml`: `0 0-12 * * *` → `7 0-12 * * *`
- [x] `schedule_cafeteria.yml`: `0 0-12 * * *` → `17 0-12 * * *`
- [x] `schedule_academic_calendar.yml`: `0 0-12 * * *` → `27 0-12 * * *`
- [ ] 스케줄이 `:07`, `:37` 기준으로 실행되는지 확인
- [ ] 워크플로 실행 간격이 안정적으로 유지되는지 모니터링
- [ ] 기존 irregular execution 문제 재발 여부 확인

## 📎 개발 일지 및 참고 자료

- [Troubleshooting workflows](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows)
- [Events that trigger workflows - schedule](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동화된 워크플로우의 실행 일정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->